### PR TITLE
Fixes Johnny-Five SVG sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,8 +152,8 @@
     <a href="http://www.meetup.com/nodebots/" class="btn btn-primary bg-yellow black mb3" target="_blank">RSVP for the Next Meetup</a>
   </section>
   <section class="clearfix overflow-hidden">
-    <div class="right mr3 relative" style="height: 300px">
-      <a href="http://johnny-five.io" class="block" target="_blank">
+    <div class="right mr3 relative">
+      <a href="http://johnny-five.io" class="block" target="_blank" style="height: 300px">
       <svg version="1.1" id="johnny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
     	 width="368.02px" height="657.422px" viewBox="0 0 368.02 657.422" enable-background="new 0 0 368.02 657.422"
     	 xml:space="preserve">


### PR DESCRIPTION
Fixes #2 

Turns out this was an issue with the Johnny-Five SVG filling 100% height of its parent anchor tag, which was larger than the 300px height of the parent div. Thanks to @ArmandoAmador for spotting it. 

Chrome:
<img width="1668" alt="screen shot 2016-01-04 at 11 39 15 am" src="https://cloud.githubusercontent.com/assets/3051193/12094718/3214cd06-b2d8-11e5-9fce-d37c616d1122.png">

Firefox:
<img width="1613" alt="screen shot 2016-01-04 at 11 38 51 am" src="https://cloud.githubusercontent.com/assets/3051193/12094721/372e1d06-b2d8-11e5-91a6-11d19f31907b.png">
