### PR TITLE
fixes js to not hide Johnny if no room to scroll

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
-if (window.pageYOffset !== undefined) {
+var totalScroll = document.body.scrollHeight - window.innerHeight;
+
+if (window.pageYOffset !== undefined && totalScroll > 0) {
   var johnny = document.getElementById('johnny');
-  var totalScroll = document.body.scrollHeight - window.innerHeight;
 
   johnny.style.transform = "translateX(100%)";
 


### PR DESCRIPTION
Fixes case where there is no room to scroll because the screen/window is large enough to fit the entire site. Now Johnny-Five won't hide is there is no room to scroll into view. 
